### PR TITLE
Update sqltable.py

### DIFF
--- a/sphinxcontrib/sqltable.py
+++ b/sphinxcontrib/sqltable.py
@@ -69,7 +69,8 @@ class SQLTable(Table):
         try:
             query = '\n'.join(self.content)
             LOG.info('Running query %r' % query)
-            results = engine.execute(query)
+            with engine.connect() as conn:
+                results = conn.execute(sqlalchemy.text(query))
         except Exception as err:
             error = self.state_machine.reporter.error(
                 u'Error with query %s for sqltable: %s' % (


### PR DESCRIPTION
Fix to accommodate SQLAlchemy 2.0 engine connection/execution interface where engine.execute no longer exists.